### PR TITLE
Add time import to service manager

### DIFF
--- a/Realm Server 1.12/service_manager.py
+++ b/Realm Server 1.12/service_manager.py
@@ -1,5 +1,6 @@
 import subprocess
 import logging
+import time
 
 class ServiceManager:
     def __init__(self):


### PR DESCRIPTION
## Summary
- ensure `service_manager.py` imports the `time` module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6880196f6f648328a6a167453ac4ae32