### PR TITLE
Fix missing json imports

### DIFF
--- a/Realm Server 1.12/extensions/auth_service.py
+++ b/Realm Server 1.12/extensions/auth_service.py
@@ -1,6 +1,7 @@
 from flask import Flask, request, jsonify
 import pymysql
 import logging
+import json
 
 app = Flask(__name__)
 

--- a/Realm Server 1.12/extensions/world_service.py
+++ b/Realm Server 1.12/extensions/world_service.py
@@ -1,6 +1,7 @@
 from flask import Flask, request, jsonify
 import pymysql
 import logging
+import json
 
 app = Flask(__name__)
 


### PR DESCRIPTION
## Summary
- add json imports in auth_service and world_service extensions

## Testing
- `python3 -m py_compile 'Realm Server 1.12/extensions/auth_service.py'`
- `python3 -m py_compile 'Realm Server 1.12/extensions/world_service.py'`


------
https://chatgpt.com/codex/tasks/task_e_688019bc366c832881d6cc0d01a2a3d5