### PR TITLE
Add world DB schema generation

### DIFF
--- a/Realm Server 1.12/sql/models/world_models.py
+++ b/Realm Server 1.12/sql/models/world_models.py
@@ -1,0 +1,53 @@
+from sqlalchemy import Column, Integer, String, Float, DateTime, ForeignKey
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship
+from datetime import datetime
+
+Base = declarative_base()
+
+class Map(Base):
+    __tablename__ = "maps"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String(255), nullable=False)
+    description = Column(String(255))
+
+    zones = relationship("Zone", back_populates="map")
+    spawns = relationship("Spawn", back_populates="map")
+
+class Zone(Base):
+    __tablename__ = "zones"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    map_id = Column(Integer, ForeignKey("maps.id"), nullable=False)
+    name = Column(String(255), nullable=False)
+    zone_type = Column(String(50))
+
+    map = relationship("Map", back_populates="zones")
+    spawns = relationship("Spawn", back_populates="zone")
+
+class Spawn(Base):
+    __tablename__ = "spawns"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    map_id = Column(Integer, ForeignKey("maps.id"), nullable=False)
+    zone_id = Column(Integer, ForeignKey("zones.id"), nullable=True)
+    x = Column(Float, nullable=False)
+    y = Column(Float, nullable=False)
+    z = Column(Float, nullable=False)
+    spawn_type = Column(String(50), nullable=False)
+
+    map = relationship("Map", back_populates="spawns")
+    zone = relationship("Zone", back_populates="spawns")
+
+class PlayerPosition(Base):
+    __tablename__ = "player_positions"
+
+    player_id = Column(Integer, primary_key=True)
+    map_id = Column(Integer, ForeignKey("maps.id"), nullable=False)
+    x = Column(Float, nullable=False)
+    y = Column(Float, nullable=False)
+    z = Column(Float, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    map = relationship("Map")

--- a/Realm Server 1.12/sql/world_db.py
+++ b/Realm Server 1.12/sql/world_db.py
@@ -1,80 +1,16 @@
-import pymysql
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from .models.world_models import Base
 
-def create_auth_database(connection):
-    """Create the Authentication database and its tables."""
-    with connection.cursor() as cursor:
-        # Create the Authentication database
-        cursor.execute("CREATE DATABASE IF NOT EXISTS auth_db;")
-        connection.select_db("auth_db")
-        
-        # Create Accounts table
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS accounts (
-                id INT AUTO_INCREMENT PRIMARY KEY,
-                username VARCHAR(255) UNIQUE NOT NULL,
-                password_hash VARCHAR(255) NOT NULL,
-                email VARCHAR(255) UNIQUE NOT NULL,
-                is_banned BOOLEAN DEFAULT FALSE,
-                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-                last_login DATETIME NULL,
-                permission_level INT DEFAULT 0
-            );
-        """)
 
-        # Create Bans table
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS bans (
-                id INT AUTO_INCREMENT PRIMARY KEY,
-                account_id INT,
-                ip_address VARCHAR(255) NULL,
-                reason TEXT NOT NULL,
-                banned_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-                FOREIGN KEY (account_id) REFERENCES accounts(id)
-            );
-        """)
-
-        # Create Login Attempts table
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS login_attempts (
-                id INT AUTO_INCREMENT PRIMARY KEY,
-                account_id INT NULL,
-                ip_address VARCHAR(255) NOT NULL,
-                status ENUM('success', 'failure') NOT NULL,
-                attempted_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-                FOREIGN KEY (account_id) REFERENCES accounts(id)
-            );
-        """)
-
-        # Create Sessions table
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS sessions (
-                id INT AUTO_INCREMENT PRIMARY KEY,
-                account_id INT NOT NULL,
-                session_key VARCHAR(255) UNIQUE NOT NULL,
-                ip_address VARCHAR(255) NOT NULL,
-                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-                expires_at DATETIME NOT NULL,
-                FOREIGN KEY (account_id) REFERENCES accounts(id)
-            );
-        """)
-
-        connection.commit()
-    print("Authentication database and tables created successfully.")
-
-if __name__ == "__main__":
-    # Prompt for MySQL credentials
-    host = input("Enter MySQL host (default: localhost): ") or "localhost"
-    user = input("Enter MySQL user (default: root): ") or "root"
-    password = input("Enter MySQL password: ")
-
-    # Connect to MySQL server
-    connection = pymysql.connect(
-        host=host,
-        user=user,
-        password=password
-    )
-
+def run(config):
+    """Generate the World Database schema using SQLAlchemy."""
     try:
-        create_auth_database(connection)
-    finally:
-        connection.close()
+        DATABASE_URL = (
+            f"mysql+pymysql://{config['user']}:{config['password']}@{config['host']}/world_db"
+        )
+        engine = create_engine(DATABASE_URL)
+        Base.metadata.create_all(engine)
+        print("World database and tables created successfully.")
+    except Exception as e:
+        print(f"Error during World Database generation: {e}")


### PR DESCRIPTION
## Summary
- implement SQLAlchemy models for world database tables
- add `run(config)` in `world_db.py` similar to other database modules

## Testing
- `python -m py_compile Realm\ Server\ 1.12/sql/world_db.py Realm\ Server\ 1.12/sql/models/world_models.py`

------
https://chatgpt.com/codex/tasks/task_e_68801b14794883288953c2b499d083a7