### PR TITLE
Add Realm Server requirements and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,14 @@ Open World Building - Players will be able to create empires (similar to guilds 
 <BR>
 <BR>
 We will add more to the list as features are confirmed and their mechanics and have more details.
+
+## Setup
+
+To install the Python dependencies for the Realm Server:
+
+```bash
+cd "Realm Server 1.12"
+pip install -r requirements.txt
+```
+
+This installs `flask`, `pymysql`, `sqlalchemy` and `pytest`.

--- a/Realm Server 1.12/requirements.txt
+++ b/Realm Server 1.12/requirements.txt
@@ -1,0 +1,4 @@
+flask
+pymysql
+sqlalchemy
+pytest


### PR DESCRIPTION
## Summary
- add required Python modules for `Realm Server 1.12`
- document how to install them in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68801f30c55c83289aadd435e14c72d7