### PR TITLE
Add runtime terrain editor UI

### DIFF
--- a/Realm/Assets/Scripts/RuntimeTerrainEditor.cs
+++ b/Realm/Assets/Scripts/RuntimeTerrainEditor.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using Digger.Modules.Core.Sources;
+using Digger.Modules.Runtime.Sources;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class RuntimeTerrainEditor : MonoBehaviour
+{
+    [Header("Digger Master Runtime")]
+    [SerializeField] private DiggerMasterRuntime diggerMasterRuntime;
+
+    [Header("UI Elements")]
+    [SerializeField] private Dropdown brushDropdown;
+    [SerializeField] private Dropdown actionDropdown;
+    [SerializeField] private Slider sizeSlider;
+
+    private void Awake()
+    {
+        if (!diggerMasterRuntime)
+        {
+            diggerMasterRuntime = FindObjectOfType<DiggerMasterRuntime>();
+        }
+
+        PopulateDropdown(brushDropdown, typeof(BrushType));
+        PopulateDropdown(actionDropdown, typeof(ActionType));
+    }
+
+    private static void PopulateDropdown(Dropdown dropdown, System.Type enumType)
+    {
+        if (dropdown == null)
+            return;
+
+        dropdown.ClearOptions();
+        dropdown.AddOptions(new List<string>(System.Enum.GetNames(enumType)));
+        dropdown.value = 0;
+    }
+
+    public void OnBrushChanged(int index)
+    {
+        // Method kept for Unity UI events
+    }
+
+    public void OnActionChanged(int index)
+    {
+        // Method kept for Unity UI events
+    }
+
+    public void OnSizeChanged(float value)
+    {
+        // Method kept for Unity UI events
+    }
+
+    private BrushType SelectedBrush => brushDropdown ? (BrushType)brushDropdown.value : BrushType.Sphere;
+    private ActionType SelectedAction => actionDropdown ? (ActionType)actionDropdown.value : ActionType.Dig;
+    private float SelectedSize => sizeSlider ? sizeSlider.value : 4f;
+
+    private void Update()
+    {
+        if (!diggerMasterRuntime)
+            return;
+
+        if (Input.GetMouseButton(0))
+        {
+            if (Physics.Raycast(transform.position, transform.forward, out var hit, 2000f))
+            {
+                diggerMasterRuntime.ModifyAsyncBuffured(hit.point, SelectedBrush, SelectedAction, 0, 0.5f, SelectedSize);
+            }
+        }
+    }
+}

--- a/Realm/README.md
+++ b/Realm/README.md
@@ -26,3 +26,6 @@ According to `Assets/Digger/README.txt`, it requires the **Burst** package and, 
 1. Open **Window > Package Manager**.
 2. Install **Burst** (and **AI Navigation** if using Digger Pro).
 After installation the menu **Tools > Digger** becomes available.
+
+## Runtime Terrain Editor
+The script `RuntimeTerrainEditor.cs` under `Assets/Scripts` provides a simple in-game interface for editing terrain when using the Digger plugin. Attach the component to a GameObject along with **DiggerMasterRuntime** and connect dropdowns for the brush and action types as well as a slider for the brush size. At runtime you can change these parameters and left-click in the scene to apply the modifications.


### PR DESCRIPTION
## Summary
- add `RuntimeTerrainEditor.cs` script for runtime editing of Digger terrain
- document new script in `Realm/README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688020fe1b488328ba4af57ae29d9600