### PR TITLE
Update config loading

### DIFF
--- a/Realm Server 1.12/config_manager.py
+++ b/Realm Server 1.12/config_manager.py
@@ -4,20 +4,35 @@ import os
 CONFIG_FILE = "config.json"
 
 def get_mysql_credentials():
-    """Load MySQL credentials or prompt user for them."""
+    """Load MySQL credentials from config.json or prompt the user."""
     if os.path.exists(CONFIG_FILE):
         with open(CONFIG_FILE, "r") as file:
-            return json.load(file).get("mysql")
+            cfg = json.load(file)
+        return {
+            "host": cfg.get("mysql_host", "localhost"),
+            "user": cfg.get("mysql_user", "root"),
+            "password": cfg.get("mysql_password", ""),
+            "port": cfg.get("mysql_port", 3306),
+        }
 
-    # Prompt for credentials if not found
+    # Prompt for credentials if config does not exist
     credentials = {
         "host": input("Enter MySQL host (default: localhost): ") or "localhost",
         "user": input("Enter MySQL user (default: root): ") or "root",
         "password": input("Enter MySQL password: "),
+        "port": int(input("Enter MySQL port (default: 3306): ") or 3306),
     }
 
-    # Save credentials to config.json
     with open(CONFIG_FILE, "w") as file:
-        json.dump({"mysql": credentials}, file, indent=4)
+        json.dump(
+            {
+                "mysql_user": credentials["user"],
+                "mysql_password": credentials["password"],
+                "mysql_host": credentials["host"],
+                "mysql_port": credentials["port"],
+            },
+            file,
+            indent=4,
+        )
 
     return credentials

--- a/Realm Server 1.12/extensions/auth_service.py
+++ b/Realm Server 1.12/extensions/auth_service.py
@@ -2,6 +2,7 @@ from flask import Flask, request, jsonify
 import pymysql
 import logging
 import json
+import os
 
 app = Flask(__name__)
 
@@ -17,7 +18,8 @@ logging.basicConfig(
 
 # Database Connection Helper
 def get_db_connection():
-    with open("config/server_config.json", "r") as file:
+    config_path = os.path.join(os.path.dirname(__file__), "..", "config.json")
+    with open(config_path, "r") as file:
         config = json.load(file)
     return pymysql.connect(
         host=config["mysql_host"],

--- a/Realm Server 1.12/tests/test_config_manager.py
+++ b/Realm Server 1.12/tests/test_config_manager.py
@@ -1,0 +1,29 @@
+import json
+import importlib.util
+import os
+
+MODULE_PATH = os.path.join(os.path.dirname(__file__), "..", "config_manager.py")
+spec = importlib.util.spec_from_file_location("config_manager", MODULE_PATH)
+config_manager = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(config_manager)
+
+
+def test_get_mysql_credentials_reads_new_format(tmp_path, monkeypatch):
+    cfg = {
+        "mysql_user": "tester",
+        "mysql_password": "secret",
+        "mysql_host": "db.example.com",
+        "mysql_port": 3307,
+    }
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps(cfg))
+    monkeypatch.setattr(config_manager, "CONFIG_FILE", str(cfg_path))
+
+    creds = config_manager.get_mysql_credentials()
+
+    assert creds == {
+        "host": "db.example.com",
+        "user": "tester",
+        "password": "secret",
+        "port": 3307,
+    }


### PR DESCRIPTION
## Summary
- update `auth_service` to read from new `config.json`
- revise `config_manager.get_mysql_credentials` to handle new config keys
- add test for loading credentials from `config.json`

## Testing
- `pytest -q Realm Server 1.12/tests`

------
https://chatgpt.com/codex/tasks/task_e_6880227bcf4c83288cff94c6862b99c3