### PR TITLE
Add session handling to auth service

### DIFF
--- a/Realm Server 1.12/tests/test_auth_service.py
+++ b/Realm Server 1.12/tests/test_auth_service.py
@@ -2,14 +2,16 @@ import importlib.util
 import os
 import pytest
 import bcrypt
+from datetime import datetime, timedelta
 
 # Ensure log directory exists for auth_service logging
 os.makedirs("logs", exist_ok=True)
 
 # Helper classes for mocking database connections
 class DummyCursor:
-    def __init__(self, user):
+    def __init__(self, user=None, session=None):
         self.user = user
+        self.session = session
         self.executed = []
         self._fetch = None
 
@@ -17,6 +19,8 @@ class DummyCursor:
         self.executed.append((sql, params))
         if "FROM users" in sql and "SELECT" in sql:
             self._fetch = self.user
+        elif "FROM sessions" in sql and "SELECT" in sql:
+            self._fetch = self.session
 
     def fetchone(self):
         return self._fetch
@@ -28,8 +32,8 @@ class DummyCursor:
         pass
 
 class DummyConnection:
-    def __init__(self, user=None):
-        self.cursor_obj = DummyCursor(user)
+    def __init__(self, user=None, session=None):
+        self.cursor_obj = DummyCursor(user, session)
 
     def cursor(self):
         return self.cursor_obj
@@ -98,3 +102,41 @@ def test_register_hashes_password(monkeypatch, client):
     stored_hash = inserted[1]
     assert stored_hash != "secret"
     assert bcrypt.checkpw(b"secret", stored_hash.encode())
+
+
+def test_login_creates_session(monkeypatch, client):
+    hashed = bcrypt.hashpw(b"pw", bcrypt.gensalt()).decode()
+    conn = DummyConnection({"id": 5, "is_banned": 0, "password_hash": hashed})
+    monkeypatch.setattr(auth_service, "get_db_connection", lambda: conn)
+
+    resp = client.post("/auth/login", json={"username": "u", "password": "pw"})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "session_key" in data
+
+    inserts = [q for q in conn.cursor_obj.executed if "INSERT INTO sessions" in q[0]]
+    assert len(inserts) == 1
+    assert inserts[0][1][1] == data["session_key"]
+
+
+def test_validate_session(monkeypatch, client):
+    future = datetime.utcnow() + timedelta(hours=1)
+
+    def fake_conn():
+        return DummyConnection(session={"user_id": 7, "expires_at": future})
+
+    monkeypatch.setattr(auth_service, "get_db_connection", fake_conn)
+    resp = client.post("/auth/validate_session", json={"session_key": "abc"})
+    assert resp.status_code == 200
+    assert resp.get_json() == {"status": "valid", "user_id": 7}
+
+
+def test_logout(monkeypatch, client):
+    conn = DummyConnection()
+    monkeypatch.setattr(auth_service, "get_db_connection", lambda: conn)
+
+    resp = client.post("/auth/logout", json={"session_key": "abc"})
+    assert resp.status_code == 200
+    dels = [q for q in conn.cursor_obj.executed if "DELETE FROM sessions" in q[0]]
+    assert len(dels) == 1
+    assert dels[0][1][0] == "abc"


### PR DESCRIPTION
## Summary
- generate session on login and add validation/logout routes
- cover new session behavior in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68802519ce388328bec170c2fcaffb94