### PR TITLE
Add password reset functionality

### DIFF
--- a/Realm Server 1.12/sql/models/auth_models.py
+++ b/Realm Server 1.12/sql/models/auth_models.py
@@ -51,3 +51,17 @@ class Session(Base):
     expires_at = Column(DateTime, nullable=False)
 
     account = relationship("Account", back_populates="sessions")
+
+
+class PasswordResetToken(Base):
+    """Model for password reset tokens."""
+
+    __tablename__ = "password_reset_tokens"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    account_id = Column(Integer, ForeignKey("accounts.id"), nullable=False)
+    token = Column(String(255), unique=True, nullable=False)
+    expires_at = Column(DateTime, nullable=False)
+    used = Column(Boolean, default=False)
+
+    account = relationship("Account")


### PR DESCRIPTION
## Summary
- create `PasswordResetToken` model
- implement request and reset password endpoints
- test password reset flow and token expiration

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68802681ebd88328876fa5f06f18c2f4