### PR TITLE
Add character management endpoints

### DIFF
--- a/Realm Server 1.12/CharacterAPI.cs
+++ b/Realm Server 1.12/CharacterAPI.cs
@@ -1,0 +1,72 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.Networking;
+using System.Text;
+
+public class CharacterAPI : MonoBehaviour
+{
+    private string baseUrl = "http://localhost:5003/characters";
+
+    public IEnumerator CreateCharacter(int accountId, string name, int classId, string appearance)
+    {
+        var payload = JsonUtility.ToJson(new CharacterCreate{ account_id = accountId, name = name, class_id = classId, appearance = appearance });
+        using (UnityWebRequest req = new UnityWebRequest(baseUrl, "POST"))
+        {
+            byte[] bodyRaw = Encoding.UTF8.GetBytes(payload);
+            req.uploadHandler = new UploadHandlerRaw(bodyRaw);
+            req.downloadHandler = new DownloadHandlerBuffer();
+            req.SetRequestHeader("Content-Type", "application/json");
+            yield return req.SendWebRequest();
+            Debug.Log($"CreateCharacter response: {req.downloadHandler.text}");
+        }
+    }
+
+    public IEnumerator GetCharacters(int accountId)
+    {
+        string url = baseUrl + "/" + accountId;
+        using (UnityWebRequest req = UnityWebRequest.Get(url))
+        {
+            yield return req.SendWebRequest();
+            Debug.Log($"Characters: {req.downloadHandler.text}");
+        }
+    }
+
+    public IEnumerator UpdateCharacter(int charId, int classId, string appearance)
+    {
+        var payload = JsonUtility.ToJson(new CharacterUpdate{ class_id = classId, appearance = appearance });
+        using (UnityWebRequest req = new UnityWebRequest(baseUrl + "/" + charId, "PUT"))
+        {
+            byte[] bodyRaw = Encoding.UTF8.GetBytes(payload);
+            req.uploadHandler = new UploadHandlerRaw(bodyRaw);
+            req.downloadHandler = new DownloadHandlerBuffer();
+            req.SetRequestHeader("Content-Type", "application/json");
+            yield return req.SendWebRequest();
+            Debug.Log($"UpdateCharacter response: {req.downloadHandler.text}");
+        }
+    }
+
+    public IEnumerator DeleteCharacter(int charId)
+    {
+        using (UnityWebRequest req = UnityWebRequest.Delete(baseUrl + "/" + charId))
+        {
+            yield return req.SendWebRequest();
+            Debug.Log($"DeleteCharacter response: {req.downloadHandler.text}");
+        }
+    }
+
+    [System.Serializable]
+    private class CharacterCreate
+    {
+        public int account_id;
+        public string name;
+        public int class_id;
+        public string appearance;
+    }
+
+    [System.Serializable]
+    private class CharacterUpdate
+    {
+        public int class_id;
+        public string appearance;
+    }
+}

--- a/Realm Server 1.12/sql/models/world_models.py
+++ b/Realm Server 1.12/sql/models/world_models.py
@@ -51,3 +51,26 @@ class PlayerPosition(Base):
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
     map = relationship("Map")
+
+class Class(Base):
+    __tablename__ = "classes"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String(50), nullable=False)
+    description = Column(String(255))
+
+    characters = relationship("Character", back_populates="class_")
+
+
+class Character(Base):
+    __tablename__ = "characters"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    account_id = Column(Integer, nullable=False)
+    name = Column(String(255), nullable=False)
+    class_id = Column(Integer, ForeignKey("classes.id"), nullable=False)
+    appearance = Column(String(255))
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    class_ = relationship("Class", back_populates="characters")

--- a/Realm Server 1.12/sql/world_db.py
+++ b/Realm Server 1.12/sql/world_db.py
@@ -1,6 +1,7 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-from .models.world_models import Base
+# Import models so that SQLAlchemy registers them with the metadata
+from .models.world_models import Base, Character, Class
 
 
 def run(config):

--- a/Realm Server 1.12/tests/test_character_service.py
+++ b/Realm Server 1.12/tests/test_character_service.py
@@ -1,0 +1,88 @@
+import importlib.util
+import os
+import pytest
+
+MODULE_PATH = os.path.join(os.path.dirname(__file__), "..", "extensions", "world_service.py")
+spec = importlib.util.spec_from_file_location("world_service", MODULE_PATH)
+world_service = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(world_service)
+
+world_service.app.testing = True
+
+class DummyCursor:
+    def __init__(self, fetch=None, rowcount=1):
+        self.executed = []
+        self.fetch = fetch
+        self.rowcount = rowcount
+        self.lastrowid = 1
+
+    def execute(self, sql, params=None):
+        self.executed.append((sql, params))
+
+    def fetchall(self):
+        return self.fetch
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+class DummyConnection:
+    def __init__(self, fetch=None, rowcount=1):
+        self.cursor_obj = DummyCursor(fetch, rowcount)
+
+    def cursor(self):
+        return self.cursor_obj
+
+    def commit(self):
+        pass
+
+    def close(self):
+        pass
+
+@pytest.fixture
+def client():
+    return world_service.app.test_client()
+
+
+def test_create_character(monkeypatch, client):
+    conn = DummyConnection()
+    monkeypatch.setattr(world_service, "get_db_connection", lambda: conn)
+    resp = client.post("/characters", json={"account_id":1,"name":"Hero","class_id":2,"appearance":"a"})
+    assert resp.status_code == 201
+    assert any("INSERT INTO characters" in q[0] for q in conn.cursor_obj.executed)
+
+
+def test_list_characters(monkeypatch, client):
+    data = [{"id":1,"account_id":1,"name":"Hero","class_id":2,"appearance":"a"}]
+    conn = DummyConnection(fetch=data)
+    monkeypatch.setattr(world_service, "get_db_connection", lambda: conn)
+    resp = client.get("/characters/1")
+    assert resp.status_code == 200
+    assert resp.get_json() == data
+
+
+def test_update_character(monkeypatch, client):
+    conn = DummyConnection()
+    monkeypatch.setattr(world_service, "get_db_connection", lambda: conn)
+    resp = client.put("/characters/5", json={"class_id":3,"appearance":"b"})
+    assert resp.status_code == 200
+    updates = [q for q in conn.cursor_obj.executed if "UPDATE characters" in q[0]]
+    assert len(updates) == 1
+
+
+def test_delete_character(monkeypatch, client):
+    conn = DummyConnection(rowcount=1)
+    monkeypatch.setattr(world_service, "get_db_connection", lambda: conn)
+    resp = client.delete("/characters/5")
+    assert resp.status_code == 200
+    dels = [q for q in conn.cursor_obj.executed if "DELETE FROM characters" in q[0]]
+    assert len(dels) == 1
+
+
+def test_delete_character_not_found(monkeypatch, client):
+    conn = DummyConnection(rowcount=0)
+    monkeypatch.setattr(world_service, "get_db_connection", lambda: conn)
+    resp = client.delete("/characters/99")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- extend world models with `Class` and `Character`
- ensure migration imports in world_db
- expose character CRUD routes in world_service
- add Unity CharacterAPI calls
- test character routes

## Testing
- `pip install -r Realm Server 1.12/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68802d8048108328bc360035ae23012d